### PR TITLE
Fix google translator outdated dom selector

### DIFF
--- a/translators/google.js
+++ b/translators/google.js
@@ -4,7 +4,7 @@ var active = window.location.href !== "about:blank";
 function checkFinished() {
     if (!active) return;
 
-    let spans = [].slice.call(document.querySelectorAll('span.HwtZe > span > span'));
+    let spans = [].slice.call(document.querySelectorAll('span.ryNqvb'));
     let text = spans.reduce(function (res, i) {
         return res + ' ' + i.innerText;
     }, '');


### PR DESCRIPTION
Fixed the Google translation web scraping script in `translators/google.js` by updating the outdated DOM selector `span.HwtZe > span > span` to the current one `span.ryNqvb`.

---
*PR created automatically by Jules for task [14541572896839490796](https://jules.google.com/task/14541572896839490796) started by @Max97k*