### PR TITLE
Refactor ResultWidget to add Windows 11 modern UX animations

### DIFF
--- a/src/represent/resultwidget.cpp
+++ b/src/represent/resultwidget.cpp
@@ -12,6 +12,7 @@
 #include <QMenu>
 #include <QMouseEvent>
 #include <QScreen>
+#include <QPropertyAnimation>
 
 ResultWidget::ResultWidget(Manager &manager, Representer &representer,
                            const Settings &settings, QWidget *parent)
@@ -24,6 +25,8 @@ ResultWidget::ResultWidget(Manager &manager, Representer &representer,
   , separator_(new QLabel(this))
   , translated_(new QLabel(this))
   , contextMenu_(new QMenu(this))
+  , fadeAnimation_(new QPropertyAnimation(this, "windowOpacity", this))
+  , geometryAnimation_(new QPropertyAnimation(this, "geometry", this))
 {
   setWindowFlags(Qt::FramelessWindowHint | Qt::NoDropShadowWindowHint |
                  Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
@@ -74,11 +77,52 @@ ResultWidget::ResultWidget(Manager &manager, Representer &representer,
   layout->setSpacing(0);
 
   updateSettings();
+
+  fadeAnimation_->setDuration(250);
+  fadeAnimation_->setEasingCurve(QEasingCurve::InOutQuad);
+  connect(fadeAnimation_, &QPropertyAnimation::finished, this, [this]() {
+    if (animatingHide_) {
+      animatingHide_ = false;
+      QFrame::setVisible(false);
+    }
+  });
+
+  geometryAnimation_->setDuration(300);
+  geometryAnimation_->setEasingCurve(QEasingCurve::OutCubic);
 }
 
 const TaskPtr &ResultWidget::task() const
 {
   return task_;
+}
+
+void ResultWidget::setVisible(bool visible)
+{
+  if (visible) {
+    if (animatingHide_) {
+      fadeAnimation_->stop();
+      animatingHide_ = false;
+    }
+
+    if (!isVisible()) {
+      setWindowOpacity(0.0);
+      QFrame::setVisible(true);
+    }
+
+    fadeAnimation_->stop();
+    fadeAnimation_->setStartValue(windowOpacity());
+    fadeAnimation_->setEndValue(1.0);
+    fadeAnimation_->start();
+  } else {
+    if (!isVisible() || animatingHide_)
+      return;
+
+    animatingHide_ = true;
+    fadeAnimation_->stop();
+    fadeAnimation_->setStartValue(windowOpacity());
+    fadeAnimation_->setEndValue(0.0);
+    fadeAnimation_->start();
+  }
 }
 
 void ResultWidget::show(const TaskPtr &task)
@@ -105,18 +149,18 @@ void ResultWidget::show(const TaskPtr &task)
   const auto mustShowRecognized = settings_.showRecognized || !gotTranslation;
   recognized_->setVisible(mustShowRecognized);
 
-  show();
   adjustSize();
 
+  auto targetSize = size();
   // window should not be smaller than selected image
   if (!imagePlaceholder_->isVisible())
-    resize(std::max(width(), task->captured.width()),
-           std::max(height(), task->captured.height()));
+    targetSize = QSize(std::max(targetSize.width(), task->captured.width()),
+                       std::max(targetSize.height(), task->captured.height()));
 
   // if window is wider than image then image should be at horizontal center
   const auto correctionToCenterImage =
-      QPoint((width() - task->captured.width()) / 2, 2 * lineWidth());
-  auto rect = QRect(task->capturePoint - correctionToCenterImage, size());
+      QPoint((targetSize.width() - task->captured.width()) / 2, 2 * lineWidth());
+  auto rect = QRect(task->capturePoint - correctionToCenterImage, targetSize);
 
   auto screen = QApplication::screenAt(task->capturePoint);
   SOFT_ASSERT(screen, return );
@@ -153,7 +197,16 @@ void ResultWidget::show(const TaskPtr &task)
     layout->insertWidget(++index, translated_);
   }
 
-  move(rect.topLeft());
+  if (isVisible() && !animatingHide_) {
+    geometryAnimation_->stop();
+    geometryAnimation_->setStartValue(geometry());
+    geometryAnimation_->setEndValue(rect);
+    geometryAnimation_->start();
+  } else {
+    setGeometry(rect);
+  }
+
+  show();
 
   activateWindow();
 }

--- a/src/represent/resultwidget.h
+++ b/src/represent/resultwidget.h
@@ -6,6 +6,7 @@
 
 class QLabel;
 class QMenu;
+class QPropertyAnimation;
 
 class ResultWidget : public QFrame
 {
@@ -18,6 +19,8 @@ public:
   void show(const TaskPtr& task);
   using QWidget::show;
   void updateSettings();
+
+  void setVisible(bool visible) override;
 
 protected:
   void mousePressEvent(QMouseEvent* event) override;
@@ -38,4 +41,8 @@ private:
   QLabel* translated_;
   QMenu* contextMenu_;
   QPoint lastPos_;
+
+  QPropertyAnimation* fadeAnimation_;
+  QPropertyAnimation* geometryAnimation_;
+  bool animatingHide_{false};
 };


### PR DESCRIPTION
This update adds smooth visual transitions to the translation popup window (`ResultWidget`), aligning its appearance and feel with modern Windows 11 UX paradigms.

Specifically:
- Adds fade-in and fade-out animations when the popup is shown and hidden.
- Adds geometry animations to smoothly resize and move the popup when transitioning between different translations or contexts.

---
*PR created automatically by Jules for task [12521047423126256383](https://jules.google.com/task/12521047423126256383) started by @Max97k*