### PR TITLE
Refactor asynchronous data flow using std::future and QtConcurrent

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -17,6 +17,7 @@
 #include <QMessageBox>
 #include <QNetworkProxy>
 #include <QThread>
+#include <QtConcurrent/QtConcurrent>
 
 namespace
 {
@@ -218,6 +219,38 @@ void Manager::finishTask(const TaskPtr &task)
   tray_->showSuccess();
 }
 
+void Manager::runPipelineAsync(const TaskPtr &task)
+{
+  QtConcurrent::run([this, task]() {
+    task->captureFuture->wait();
+    if (!task->isValid()) {
+      QMetaObject::invokeMethod(tray_.get(), [this, task]() { finishTask(task); }, Qt::QueuedConnection);
+      return;
+    }
+    QMetaObject::invokeMethod(tray_.get(), [this, task]() { recognizer_->recognize(task); }, Qt::QueuedConnection);
+
+    task->ocrFuture->wait();
+    if (!task->isValid()) {
+      QMetaObject::invokeMethod(tray_.get(), [this, task]() { finishTask(task); }, Qt::QueuedConnection);
+      return;
+    }
+    QMetaObject::invokeMethod(tray_.get(), [this, task]() { corrector_->correct(task); }, Qt::QueuedConnection);
+
+    task->correctFuture->wait();
+    if (!task->isValid()) {
+      QMetaObject::invokeMethod(tray_.get(), [this, task]() { finishTask(task); }, Qt::QueuedConnection);
+      return;
+    }
+
+    if (!task->targetLanguage.isEmpty()) {
+      QMetaObject::invokeMethod(tray_.get(), [this, task]() { translator_->translate(task); }, Qt::QueuedConnection);
+      task->translateFuture->wait();
+    } else {
+      QMetaObject::invokeMethod(tray_.get(), [this, task]() { translated(task); }, Qt::QueuedConnection);
+    }
+  });
+}
+
 void Manager::captured(const TaskPtr &task)
 {
   tray_->setCaptureLockedEnabled(capturer_->canCaptureLocked());
@@ -229,12 +262,8 @@ void Manager::captured(const TaskPtr &task)
   ++activeTaskCount_;
   tray_->setActiveTaskCount(activeTaskCount_);
 
-  if (!task->isValid()) {
-    finishTask(task);
-    return;
-  }
-
-  recognizer_->recognize(task);
+  task->capturePromise->set_value();
+  runPipelineAsync(task);
 }
 
 void Manager::captureCanceled()
@@ -248,12 +277,7 @@ void Manager::recognized(const TaskPtr &task)
   SOFT_ASSERT(task, return );
   LTRACE() << "recognized" << task;
 
-  if (!task->isValid()) {
-    finishTask(task);
-    return;
-  }
-
-  corrector_->correct(task);
+  task->ocrPromise->set_value();
 }
 
 void Manager::corrected(const TaskPtr &task)
@@ -261,21 +285,20 @@ void Manager::corrected(const TaskPtr &task)
   SOFT_ASSERT(task, return );
   LTRACE() << "corrected" << task;
 
-  if (!task->isValid()) {
-    finishTask(task);
-    return;
-  }
-
-  if (!task->targetLanguage.isEmpty())
-    translator_->translate(task);
-  else
-    translated(task);
+  task->correctPromise->set_value();
 }
 
 void Manager::translated(const TaskPtr &task)
 {
   SOFT_ASSERT(task, return );
   LTRACE() << "translated" << task;
+
+  try {
+    task->translatePromise->set_value();
+  } catch(const std::future_error& e) {
+    // If it was already set, ignore. This happens when there is no target language
+    // and translated() is called directly, but translatePromise isn't awaited.
+  }
 
   finishTask(task);
 

--- a/src/manager.h
+++ b/src/manager.h
@@ -11,6 +11,7 @@ public:
   ~Manager();
 
   void captured(const TaskPtr &task);
+  void runPipelineAsync(const TaskPtr &task);
   void captureCanceled();
   void recognized(const TaskPtr &task);
   void corrected(const TaskPtr &task);

--- a/src/task.h
+++ b/src/task.h
@@ -4,10 +4,12 @@
 
 #include <QDebug>
 #include <QPixmap>
+#include <future>
 
 class Task
 {
 public:
+  Task() = default;
   bool isNull() const { return captured.isNull() && !sourceLanguage.isEmpty(); }
   bool isValid() const { return error.isEmpty(); }
 
@@ -29,6 +31,16 @@ public:
 
   QString error;
   QStringList translatorErrors;
+
+  std::shared_ptr<std::promise<void>> capturePromise{std::make_shared<std::promise<void>>()};
+  std::shared_ptr<std::promise<void>> ocrPromise{std::make_shared<std::promise<void>>()};
+  std::shared_ptr<std::promise<void>> correctPromise{std::make_shared<std::promise<void>>()};
+  std::shared_ptr<std::promise<void>> translatePromise{std::make_shared<std::promise<void>>()};
+
+  std::shared_ptr<std::future<void>> captureFuture{std::make_shared<std::future<void>>(capturePromise->get_future())};
+  std::shared_ptr<std::future<void>> ocrFuture{std::make_shared<std::future<void>>(ocrPromise->get_future())};
+  std::shared_ptr<std::future<void>> correctFuture{std::make_shared<std::future<void>>(correctPromise->get_future())};
+  std::shared_ptr<std::future<void>> translateFuture{std::make_shared<std::future<void>>(translatePromise->get_future())};
 };
 
 using TaskPtr = std::shared_ptr<Task>;


### PR DESCRIPTION
Refactored data pipeline to use standard library `std::future` models and `QtConcurrent::run` to execute capture -> ocr -> translate synchronously in a non-blocking background thread without altering the specific subcomponents. Tests have passed and build artifacts are explicitly not committed.

---
*PR created automatically by Jules for task [12010698310908011077](https://jules.google.com/task/12010698310908011077) started by @Max97k*