### PR TITLE
🧹 Remove commented-out dead code in globalaction.cpp

### DIFF
--- a/src/service/globalaction.cpp
+++ b/src/service/globalaction.cpp
@@ -349,8 +349,6 @@ quint32 GlobalAction::nativeModifiers(Qt::KeyboardModifiers modifiers)
     native |= MOD_ALT;
   if (modifiers & Qt::MetaModifier)
     native |= MOD_WIN;
-  // if (modifiers & Qt::KeypadModifier)
-  // if (modifiers & Qt::GroupSwitchModifier)
   return native;
 }
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code `// if (modifiers & Qt::KeypadModifier)` and `// if (modifiers & Qt::GroupSwitchModifier)` from `GlobalAction::nativeModifiers` in `src/service/globalaction.cpp`.
💡 **Why:** Commented-out code is generally dead code. Since version control tracks history, it can be safely removed without losing work, which improves readability and maintainability.
✅ **Verification:** Verified that the code removal is isolated and does not break the build. Ran the full test suite (`python3 share/ci/test.py`), and all 10 tests passed successfully. Code review confirmed the fix is correct and safe.
✨ **Result:** A cleaner `globalaction.cpp` file without unnecessary dead code.

---
*PR created automatically by Jules for task [7605771175405192819](https://jules.google.com/task/7605771175405192819) started by @Max97k*