### PR TITLE
🧹 Remove dead commented-out code in globalaction.cpp

### DIFF
--- a/src/service/globalaction.cpp
+++ b/src/service/globalaction.cpp
@@ -349,8 +349,6 @@ quint32 GlobalAction::nativeModifiers(Qt::KeyboardModifiers modifiers)
     native |= MOD_ALT;
   if (modifiers & Qt::MetaModifier)
     native |= MOD_WIN;
-  // if (modifiers & Qt::KeypadModifier)
-  // if (modifiers & Qt::GroupSwitchModifier)
   return native;
 }
 


### PR DESCRIPTION
🎯 **What:** Removed commented-out dead code from `src/service/globalaction.cpp`.
💡 **Why:** Commented-out code acts as noise, increasing cognitive load for maintainers. Removing it improves readability and maintainability since version control history makes it easy to recover if ever needed again.
✅ **Verification:** Re-ran tests using `python3 share/ci/test.py` and confirmed no functionality was broken.
✨ **Result:** A cleaner file with no behavior change.

---
*PR created automatically by Jules for task [15363998776341294550](https://jules.google.com/task/15363998776341294550) started by @Max97k*