### PR TITLE
🧪 Add tests for LanguageCodes string matching

### DIFF
--- a/tests/languagecodes_test.cpp
+++ b/tests/languagecodes_test.cpp
@@ -1,0 +1,69 @@
+#include <gtest/gtest.h>
+#include "../src/languagecodes.h"
+
+TEST(LanguageCodesTest, IdForNameReturnsCorrectIdForKnownName) {
+  EXPECT_EQ(LanguageCodes::idForName("English"), "eng");
+  EXPECT_EQ(LanguageCodes::idForName("French"), "fra");
+  EXPECT_EQ(LanguageCodes::idForName("Chinese (Simplified)"), "chi_sim");
+  EXPECT_EQ(LanguageCodes::idForName("Any"), "any");
+}
+
+TEST(LanguageCodesTest, IdForNameReturnsInputForUnknownName) {
+  EXPECT_EQ(LanguageCodes::idForName("UnknownLanguage"), "UnknownLanguage");
+  EXPECT_EQ(LanguageCodes::idForName(""), "");
+}
+
+TEST(LanguageCodesTest, IdForTesseractReturnsCorrectIdForKnownTesseractCode) {
+  EXPECT_EQ(LanguageCodes::idForTesseract("eng"), "eng");
+  EXPECT_EQ(LanguageCodes::idForTesseract("fra"), "fra");
+  EXPECT_EQ(LanguageCodes::idForTesseract("chi_sim"), "chi_sim");
+  // "smo" has empty tesseract code in the map, so it maps back if we search for "", but "" maps to many things or nothing specific in find_if. Let's pick standard ones.
+}
+
+TEST(LanguageCodesTest, IdForTesseractReturnsInputForUnknownTesseractCode) {
+  EXPECT_EQ(LanguageCodes::idForTesseract("unknown_code"), "unknown_code");
+}
+
+TEST(LanguageCodesTest, Iso639_1ReturnsCorrectCodeForKnownId) {
+  EXPECT_EQ(LanguageCodes::iso639_1("eng"), "en");
+  EXPECT_EQ(LanguageCodes::iso639_1("fra"), "fr");
+  EXPECT_EQ(LanguageCodes::iso639_1("chi_sim"), "zh-CN");
+}
+
+TEST(LanguageCodesTest, Iso639_1ReturnsIdForUnknownId) {
+  EXPECT_EQ(LanguageCodes::iso639_1("unknown_id"), "unknown_id");
+}
+
+TEST(LanguageCodesTest, TesseractReturnsCorrectCodeForKnownId) {
+  EXPECT_EQ(LanguageCodes::tesseract("eng"), "eng");
+  EXPECT_EQ(LanguageCodes::tesseract("fra"), "fra");
+  EXPECT_EQ(LanguageCodes::tesseract("chi_sim"), "chi_sim");
+  EXPECT_EQ(LanguageCodes::tesseract("smo"), ""); // Samoan has empty tesseract
+}
+
+TEST(LanguageCodesTest, TesseractReturnsIdForUnknownId) {
+  EXPECT_EQ(LanguageCodes::tesseract("unknown_id"), "unknown_id");
+}
+
+TEST(LanguageCodesTest, NameReturnsCorrectNameForKnownId) {
+  EXPECT_EQ(LanguageCodes::name("eng"), "English");
+  EXPECT_EQ(LanguageCodes::name("fra"), "French");
+  EXPECT_EQ(LanguageCodes::name("chi_sim"), "Chinese (Simplified)");
+}
+
+TEST(LanguageCodesTest, NameReturnsIdForUnknownId) {
+  EXPECT_EQ(LanguageCodes::name("unknown_id"), "unknown_id");
+}
+
+TEST(LanguageCodesTest, AllIdsReturnsNonEmptyVector) {
+  std::vector<LanguageId> ids = LanguageCodes::allIds();
+  EXPECT_FALSE(ids.empty());
+  // Check that some known IDs are in the vector
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "eng"), ids.end());
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "fra"), ids.end());
+  EXPECT_NE(std::find(ids.begin(), ids.end(), "chi_sim"), ids.end());
+}
+
+TEST(LanguageCodesTest, AnyLanguageIdReturnsAny) {
+  EXPECT_EQ(LanguageCodes::anyLanguageId(), "any");
+}

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -6,17 +6,20 @@ QT += widgets network testlib
 INCLUDEPATH += $$PWD/../external $$PWD/../src/service
 
 HEADERS += \
+  ../src/languagecodes.h \
   ../src/service/updates.h \
   ../src/task.h \
   mocknetworkaccessmanager.h
 
 SOURCES += \
   ../external/gtest/gtest-all.cc \
+  ../src/languagecodes.cpp \
   ../src/service/geometryutils.cpp \
   ../src/service/updates.cpp \
   ../src/service/debug.cpp \
   ../external/miniz/miniz.c \
   geometryutils_test.cpp \
+  languagecodes_test.cpp \
   main.cpp \
   updates_test.cpp \
   mocknetworkaccessmanager.cpp \


### PR DESCRIPTION
🎯 **What:** Missing tests for LanguageCodes string matching addressed by writing `tests/languagecodes_test.cpp`.
📊 **Coverage:** The test file covers `idForName`, `idForTesseract`, `iso639_1`, `tesseract`, `name`, `allIds`, and `anyLanguageId` under the `LanguageCodes` namespace. It asserts matches for explicit configurations and correctly tests fallback patterns (such as retaining input when a string code is unknown).
✨ **Result:** Improved test coverage validating expected string mapping behavior for LanguageCodes across various languages without breaking existing codebase structures. All tests compile and run properly through standard suite paths.

---
*PR created automatically by Jules for task [8679619096738442792](https://jules.google.com/task/8679619096738442792) started by @Max97k*