### PR TITLE
🧪 Add unit tests for CaptureArea::task

### DIFF
--- a/share/ci/test.py
+++ b/share/ci/test.py
@@ -20,6 +20,9 @@ c.run('qmake {} "{}"'.format(os.environ.get('QMAKE_FLAGS', ''), test_pro_file))
 make_cmd = c.get_make_cmd()
 c.run(make_cmd)
 
+if platform.system() != "Windows":
+    os.environ['QT_QPA_PLATFORM'] = 'offscreen'
+
 for file in glob.glob('./**/tests*', recursive=True):
     print(file)
     c.run(file, silent=False)

--- a/tests/capturearea_test.cpp
+++ b/tests/capturearea_test.cpp
@@ -64,7 +64,8 @@ TEST_F(CaptureAreaTest, ValidTask) {
     EXPECT_EQ(task->capturePoint, offset + QPoint(10, 10));
     EXPECT_EQ(task->sourceLanguage, "eng");
     EXPECT_EQ(task->targetLanguage, "rus");
-    EXPECT_EQ(task->translators, QStringList{"google.js"});
+    EXPECT_EQ(task->translators.size(), 1);
+    EXPECT_EQ(task->translators.first(), "google.js");
     EXPECT_TRUE(task->error.isEmpty());
 }
 

--- a/tests/capturearea_test.cpp
+++ b/tests/capturearea_test.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include "../src/capture/capturearea.h"
+#include "../src/settings.h"
+#include "../src/task.h"
+
+#include <QPixmap>
+#include <QRect>
+#include <QStringList>
+
+class CaptureAreaTest : public ::testing::Test {
+protected:
+    Settings createSettings(bool doTranslation, const QString& sourceLang, const QString& targetLang, const QStringList& translators) {
+        Settings settings;
+        settings.doTranslation = doTranslation;
+        settings.sourceLanguage = sourceLang;
+        settings.targetLanguage = targetLang;
+        settings.translators = translators;
+        settings.useHunspell = true;
+        return settings;
+    }
+
+    // Helper to create a non-null QPixmap
+    QPixmap createValidPixmap() {
+        QPixmap pixmap(10, 10);
+        pixmap.fill(Qt::black);
+        return pixmap;
+    }
+};
+
+TEST_F(CaptureAreaTest, InvalidPixmap) {
+    Settings settings = createSettings(true, "eng", "rus", {"google.js"});
+    CaptureArea area(QRect(0, 0, 100, 100), settings);
+
+    QPixmap invalidPixmap; // isNull() == true
+    TaskPtr task = area.task(invalidPixmap, QPoint(0, 0));
+
+    EXPECT_EQ(task, nullptr);
+}
+
+TEST_F(CaptureAreaTest, InvalidArea) {
+    Settings settings = createSettings(true, "eng", "rus", {"google.js"});
+    CaptureArea area(QRect(0, 0, 2, 2), settings); // isValid() == false (width or height < 3)
+
+    QPixmap validPixmap = createValidPixmap();
+    TaskPtr task = area.task(validPixmap, QPoint(0, 0));
+
+    EXPECT_EQ(task, nullptr);
+}
+
+TEST_F(CaptureAreaTest, ValidTask) {
+    Settings settings = createSettings(true, "eng", "rus", {"google.js"});
+    CaptureArea area(QRect(10, 10, 50, 50), settings);
+    area.setGeneration(42);
+
+    QPixmap validPixmap = createValidPixmap();
+    QPoint offset(5, 5);
+    TaskPtr task = area.task(validPixmap, offset);
+
+    ASSERT_NE(task, nullptr);
+    EXPECT_EQ(task->generation, 42u);
+    EXPECT_EQ(task->useHunspell, true);
+    // Note: The copy operates on the size of rect_, but here we just check if it's generated
+    EXPECT_EQ(task->capturePoint, offset + QPoint(10, 10));
+    EXPECT_EQ(task->sourceLanguage, "eng");
+    EXPECT_EQ(task->targetLanguage, "rus");
+    EXPECT_EQ(task->translators, QStringList{"google.js"});
+    EXPECT_TRUE(task->error.isEmpty());
+}
+
+TEST_F(CaptureAreaTest, MissingSourceLanguage) {
+    Settings settings = createSettings(true, "", "rus", {"google.js"});
+    CaptureArea area(QRect(0, 0, 100, 100), settings);
+
+    QPixmap validPixmap = createValidPixmap();
+    TaskPtr task = area.task(validPixmap, QPoint(0, 0));
+
+    ASSERT_NE(task, nullptr);
+    EXPECT_TRUE(task->error.contains("No source language set"));
+}
+
+TEST_F(CaptureAreaTest, MissingTargetLanguage) {
+    Settings settings = createSettings(true, "eng", "", {"google.js"});
+    CaptureArea area(QRect(0, 0, 100, 100), settings);
+
+    QPixmap validPixmap = createValidPixmap();
+    TaskPtr task = area.task(validPixmap, QPoint(0, 0));
+
+    ASSERT_NE(task, nullptr);
+    EXPECT_TRUE(task->error.contains("No target language set"));
+}
+
+TEST_F(CaptureAreaTest, BothMissingLanguages) {
+    Settings settings = createSettings(true, "", "", {"google.js"});
+    CaptureArea area(QRect(0, 0, 100, 100), settings);
+
+    QPixmap validPixmap = createValidPixmap();
+    TaskPtr task = area.task(validPixmap, QPoint(0, 0));
+
+    ASSERT_NE(task, nullptr);
+    EXPECT_TRUE(task->error.contains("No source language set"));
+    EXPECT_TRUE(task->error.contains("No target language set"));
+}
+
+TEST_F(CaptureAreaTest, NoTranslationNoTargetLanguageError) {
+    // If doTranslation is false, it shouldn't care about missing target language
+    Settings settings = createSettings(false, "eng", "", {"google.js"});
+    CaptureArea area(QRect(0, 0, 100, 100), settings);
+
+    QPixmap validPixmap = createValidPixmap();
+    TaskPtr task = area.task(validPixmap, QPoint(0, 0));
+
+    ASSERT_NE(task, nullptr);
+    EXPECT_TRUE(task->error.isEmpty());
+}

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,10 +1,10 @@
-#include <QCoreApplication>
+#include <QApplication>
 
 #include <gtest/gtest.h>
 
 int main(int argc, char *argv[])
 {
-  QCoreApplication a(argc, argv);
+  QApplication a(argc, argv);
   ::testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();
 }

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -3,7 +3,7 @@ CONFIG -= app_bundle
 
 QT += widgets network testlib
 
-INCLUDEPATH += $$PWD/../external $$PWD/../src/service
+INCLUDEPATH += $$PWD/../external $$PWD/../src/service $$PWD/../src $$PWD/../src/capture
 
 HEADERS += \
   ../src/service/updates.h \
@@ -16,8 +16,10 @@ SOURCES += \
   ../src/service/updates.cpp \
   ../src/service/debug.cpp \
   ../external/miniz/miniz.c \
+  ../src/capture/capturearea.cpp \
   geometryutils_test.cpp \
   main.cpp \
   updates_test.cpp \
   mocknetworkaccessmanager.cpp \
-  translation_pipeline_test.cpp
+  translation_pipeline_test.cpp \
+  capturearea_test.cpp


### PR DESCRIPTION
🎯 **What:** The testing gap addressed is the lack of unit tests for the core task creation logic in `CaptureArea::task`. The code contains conditionals based on settings such as `doTranslation`, `sourceLanguage`, and `targetLanguage` and reports errors appropriately. It was missing validation.

📊 **Coverage:** Scenarios now tested include:
- `InvalidPixmap`: When a null QPixmap is supplied.
- `InvalidArea`: When the area dimensions are too small (< 3px).
- `ValidTask`: Standard happy path task creation checking property mapping.
- `MissingSourceLanguage`: Ensures an error is captured when the source language is omitted.
- `MissingTargetLanguage`: Ensures an error is captured when the target language is omitted.
- `BothMissingLanguages`: Handles multiple error appends correctly.
- `NoTranslationNoTargetLanguageError`: Avoids appending the missing target language error when `doTranslation` is disabled.

✨ **Result:** Increased test coverage for the `CaptureArea` component. This will allow confident refactoring of the capture pipeline and ensures properties are populated consistently as `Settings` change.

Note: `tests/main.cpp` was modified to instantiate a `QApplication` rather than a `QCoreApplication` because tests utilizing `QPixmap` operations will abort if a GUI application context is missing.

---
*PR created automatically by Jules for task [17396137324541122222](https://jules.google.com/task/17396137324541122222) started by @Max97k*