### PR TITLE
🔒 Fix insecure HTTP URL for update checking

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -22,7 +22,7 @@
 namespace
 {
 #ifdef DEVELOP
-const auto updatesUrl = "http://localhost:8081/updates.json";
+const auto updatesUrl = "https://localhost:8081/updates.json";
 #else
 const auto updatesUrl =
     "https://raw.githubusercontent.com/OneMoreGres/ScreenTranslator/master/"


### PR DESCRIPTION
🎯 **What:** Fixed an insecure HTTP URL hardcoded for localhost update checking (`http://localhost:8081/updates.json`) to use HTTPS.
⚠️ **Risk:** Hardcoded HTTP URLs can be intercepted in man-in-the-middle attacks, especially if the updates payload is unverified, allowing attackers to inject malicious updates.
🛡️ **Solution:** Changed the protocol from `http` to `https` to ensure encrypted transmission, adhering to secure communication best practices.

---
*PR created automatically by Jules for task [1755887433935292557](https://jules.google.com/task/1755887433935292557) started by @Max97k*