### PR TITLE
🧪 Add unit tests for LanguageCodes static lookup methods

### DIFF
--- a/tests/languagecodes_test.cpp
+++ b/tests/languagecodes_test.cpp
@@ -1,0 +1,37 @@
+#include <gtest/gtest.h>
+#include "languagecodes.h"
+
+TEST(LanguageCodesTest, Iso639_1_ValidIds)
+{
+  EXPECT_EQ(LanguageCodes::iso639_1("afr"), "af");
+  EXPECT_EQ(LanguageCodes::iso639_1("sqi"), "sq");
+  EXPECT_EQ(LanguageCodes::iso639_1("eng"), "en");
+}
+
+TEST(LanguageCodesTest, Iso639_1_UnknownId)
+{
+  EXPECT_EQ(LanguageCodes::iso639_1("unknown"), "unknown");
+}
+
+TEST(LanguageCodesTest, Tesseract_ValidIds)
+{
+  EXPECT_EQ(LanguageCodes::tesseract("afr"), "afr");
+  EXPECT_EQ(LanguageCodes::tesseract("eng"), "eng");
+}
+
+TEST(LanguageCodesTest, Tesseract_UnknownId)
+{
+  EXPECT_EQ(LanguageCodes::tesseract("unknown"), "unknown");
+}
+
+TEST(LanguageCodesTest, Name_ValidIds)
+{
+  // When testing without Qt translations loaded, it returns the string key.
+  EXPECT_EQ(LanguageCodes::name("afr"), "Afrikaans");
+  EXPECT_EQ(LanguageCodes::name("eng"), "English");
+}
+
+TEST(LanguageCodesTest, Name_UnknownId)
+{
+  EXPECT_EQ(LanguageCodes::name("unknown"), "unknown");
+}

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -3,11 +3,12 @@ CONFIG -= app_bundle
 
 QT += widgets network testlib
 
-INCLUDEPATH += $$PWD/../external $$PWD/../src/service
+INCLUDEPATH += $$PWD/../external $$PWD/../src/service $$PWD/../src
 
 HEADERS += \
   ../src/service/updates.h \
   ../src/task.h \
+  ../src/languagecodes.h \
   mocknetworkaccessmanager.h
 
 SOURCES += \
@@ -15,8 +16,10 @@ SOURCES += \
   ../src/service/geometryutils.cpp \
   ../src/service/updates.cpp \
   ../src/service/debug.cpp \
+  ../src/languagecodes.cpp \
   ../external/miniz/miniz.c \
   geometryutils_test.cpp \
+  languagecodes_test.cpp \
   main.cpp \
   updates_test.cpp \
   mocknetworkaccessmanager.cpp \


### PR DESCRIPTION
This change addresses the testing gap by adding tests for the static map lookups in the LanguageCodes class. 

🎯 **What:** The static lookup functions in `LanguageCodes` (like `iso639_1`, `tesseract`, and `name`) were untested.
📊 **Coverage:** The new tests cover known valid language IDs explicitly mapped in the codebase (e.g., "afr", "sqi", "eng") as well as fallback behavior when an unknown ID is provided.
✨ **Result:** Increased confidence and code coverage for core language code resolution logic, ensuring refactors or mapping additions don't accidentally break lookups.

---
*PR created automatically by Jules for task [14957377815155307086](https://jules.google.com/task/14957377815155307086) started by @Max97k*