### PR TITLE
Fix TCC compile error with utime on Linux in miniz

### DIFF
--- a/external/miniz/miniz.c
+++ b/external/miniz/miniz.c
@@ -3031,7 +3031,11 @@ static FILE *mz_freopen(const char *pPath, const char *pMode, FILE *pStream)
 #define MZ_DELETE_FILE remove
 #elif defined(__TINYC__)
 #ifndef MINIZ_NO_TIME
+#if defined(__linux) || defined(__linux__)
+#include <utime.h>
+#else
 #include <sys/utime.h>
+#endif
 #endif
 #define MZ_FOPEN(f, m) fopen(f, m)
 #define MZ_FCLOSE fclose

--- a/external/miniz/miniz.h
+++ b/external/miniz/miniz.h
@@ -145,11 +145,6 @@
    functions (such as tdefl_compress_mem_to_heap() and tinfl_decompress_mem_to_heap()) won't work. */
 /*#define MINIZ_NO_MALLOC */
 
-#if defined(__TINYC__) && (defined(__linux) || defined(__linux__))
-/* TODO: Work around "error: include file 'sys\utime.h' when compiling with tcc on Linux */
-#define MINIZ_NO_TIME
-#endif
-
 #include <stddef.h>
 
 #if !defined(MINIZ_NO_TIME) && !defined(MINIZ_NO_ARCHIVE_APIS)


### PR DESCRIPTION
This fixes a TCC compilation error on Linux inside the `miniz` library by:
- Including `<utime.h>` instead of `<sys/utime.h>` on Linux when compiling with TCC in `miniz.c`.
- Removing the workaround that defined `MINIZ_NO_TIME` when compiling with TCC on Linux in `miniz.h`.

---
*PR created automatically by Jules for task [10322194289839998058](https://jules.google.com/task/10322194289839998058) started by @Max97k*