### PR TITLE
feat: validate attribute names for Google Test properties

### DIFF
--- a/external/gtest/gtest-all.cc
+++ b/external/gtest/gtest-all.cc
@@ -3649,6 +3649,25 @@ static bool ValidateTestPropertyName(
                   << " are reserved by " << GTEST_NAME_ << ")";
     return false;
   }
+  if (property_name.empty()) {
+    ADD_FAILURE() << "Test property name cannot be empty.";
+    return false;
+  }
+  char c = property_name[0];
+  if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || c == '_')) {
+    ADD_FAILURE() << "Test property name " << property_name
+                  << " is not a valid XML attribute name. It should start with a letter or underscore.";
+    return false;
+  }
+  for (size_t i = 1; i < property_name.length(); ++i) {
+    c = property_name[i];
+    if (!((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+          (c >= '0' && c <= '9') || c == '_' || c == '-' || c == '.')) {
+      ADD_FAILURE() << "Test property name " << property_name
+                    << " is not a valid XML attribute name. It should only contain letters, digits, underscores, hyphens, or periods.";
+      return false;
+    }
+  }
   return true;
 }
 

--- a/external/gtest/gtest.h
+++ b/external/gtest/gtest.h
@@ -12978,7 +12978,6 @@ class GTEST_API_ TestResult {
 
   // Adds a failure if the key is a reserved attribute of Google Test
   // testsuite tags.  Returns true if the property is valid.
-  // FIXME: Validate attribute names are legal and human readable.
   static bool ValidateTestProperty(const std::string& xml_element,
                                    const TestProperty& test_property);
 


### PR DESCRIPTION
Resolves the task to add validation to ensure attribute names are legal and human readable in Google Test. Removed the FIXME comment from `external/gtest/gtest.h` and implemented standard XML attribute naming rules in `ValidateTestPropertyName` in `external/gtest/gtest-all.cc`. Tests pass and no scratch artifacts are included.

---
*PR created automatically by Jules for task [2476038383327048547](https://jules.google.com/task/2476038383327048547) started by @Max97k*