### PR TITLE
🔒 Fix arbitrary file overwrite vulnerability in update installer

### DIFF
--- a/src/service/updates.cpp
+++ b/src/service/updates.cpp
@@ -620,8 +620,45 @@ void UpdateDelegate::paint(QPainter *painter,
 
 //
 
+Installer::Installer(const QStringList &allowedPaths)
+  : allowedPaths_(allowedPaths)
+{
+}
+
+bool Installer::isPathAllowed(const QString &path) const
+{
+  if (allowedPaths_.isEmpty())
+    return false;
+
+  const auto absolutePath = QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+  const auto cs = Qt::CaseInsensitive;
+#else
+  const auto cs = Qt::CaseSensitive;
+#endif
+
+  for (const auto &allowedPath : allowedPaths_) {
+    auto cleanedAllowedPath =
+        QDir::cleanPath(QFileInfo(allowedPath).absoluteFilePath());
+    if (!cleanedAllowedPath.endsWith(QLatin1Char('/')))
+      cleanedAllowedPath += QLatin1Char('/');
+
+    if (absolutePath.compare(cleanedAllowedPath.chopped(1), cs) == 0 ||
+        absolutePath.startsWith(cleanedAllowedPath, cs))
+      return true;
+  }
+  return false;
+}
+
 void Installer::checkInstall(const File &file)
 {
+  if (!isPathAllowed(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Path is not allowed\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   QFileInfo installDir(QFileInfo(file.expandedPath).absolutePath());
   if (installDir.exists() && !installDir.isWritable()) {
     error_ +=
@@ -632,6 +669,12 @@ void Installer::checkInstall(const File &file)
 
 void Installer::remove(const File &file)
 {
+  if (!isPathAllowed(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Path is not allowed\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   QFile f(file.expandedPath);
   if (!f.exists())
     return;
@@ -645,6 +688,12 @@ void Installer::remove(const File &file)
 
 void Installer::install(const File &file, const QByteArray &data)
 {
+  if (!isPathAllowed(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Path is not allowed\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   auto installDir = QFileInfo(file.expandedPath).absoluteDir();
   if (!installDir.exists() && !installDir.mkpath(".")) {
     error_ += QApplication::translate("Updates", "Failed to create path\n%1")
@@ -774,6 +823,7 @@ void Updater::initView(QTreeView *view)
 
 void Updater::setExpansions(const QHash<QString, QString> &expansions)
 {
+  expansions_ = expansions;
   model_->setExpansions(expansions);
 }
 
@@ -788,7 +838,7 @@ void Updater::applyAction(Action action, const QVector<File> &files)
     LTRACE() << "applyAction" << int(action) << file.rawPath;
 
     if (action == Action::Remove) {
-      Installer installer;
+      Installer installer(expansions_.values());
       installer.remove(file);
       if (!installer.error().isEmpty()) {
         emit error(installer.error());
@@ -803,7 +853,7 @@ void Updater::applyAction(Action action, const QVector<File> &files)
       if (file.urls.isEmpty() || findDownload(file.urls.first()) != -1)
         continue;
 
-      Installer installer;
+      Installer installer(expansions_.values());
       installer.checkInstall(file);
 
       if (!installer.error().isEmpty()) {
@@ -851,7 +901,7 @@ void Updater::downloaded(const QUrl &url, const QByteArray &data)
     return;
   }
 
-  Installer installer;
+  Installer installer(expansions_.values());
   installer.install(file, unpacked);
   if (!installer.error().isEmpty()) {
     emit error(installer.error());

--- a/src/service/updates.h
+++ b/src/service/updates.h
@@ -105,13 +105,18 @@ private:
 class Installer
 {
 public:
+  explicit Installer(const QStringList& allowedPaths = {});
+
   void remove(const File& file);
   void install(const File& file, const QByteArray& data);
   void checkInstall(const File& file);
   const QString& error() const;
 
 private:
+  bool isPathAllowed(const QString& path) const;
+
   QString error_;
+  QStringList allowedPaths_;
 };
 
 class AutoChecker : public QObject
@@ -168,6 +173,7 @@ private:
   std::unique_ptr<AutoChecker> autoChecker_;
   QVector<QUrl> updateUrls_;
   QVector<File> downloading_;
+  QHash<QString, QString> expansions_;
 };
 
 }  // namespace update

--- a/tests/updates_test.cpp
+++ b/tests/updates_test.cpp
@@ -50,7 +50,7 @@ TEST(UpdateInstaller, SuccessInstall)
 {
   ASSERT_TRUE(removeFile(t1));
 
-  Installer testee;
+  Installer testee({"test"});
   testee.install(toFile(t1), data);
   ASSERT_EQ(data, readFile(t1));
   ASSERT_TRUE(testee.error().isEmpty());
@@ -60,7 +60,7 @@ TEST(UpdateInstaller, SuccessRemove)
 {
   ASSERT_TRUE(writeFile(f1, data));
 
-  Installer testee;
+  Installer testee({QFileInfo(f1).absolutePath()});
   testee.remove(toFile(f1));
   ASSERT_FALSE(QFile::exists(f1));
   ASSERT_TRUE(testee.error().isEmpty());
@@ -78,6 +78,40 @@ TEST(UpdateInstaller, FailInstallNoWritable)
   ASSERT_FALSE(testee.error().isEmpty());
 }
 #endif
+
+TEST(UpdateInstaller, PathValidation)
+{
+  Installer testee({"allowed_dir"});
+
+  // Path inside allowed_dir
+  testee.install(toFile("allowed_dir/to1.txt"), data);
+  ASSERT_TRUE(testee.error().isEmpty());
+
+  // Path outside allowed_dir
+  testee.install(toFile("unallowed_dir/to2.txt"), data);
+  ASSERT_FALSE(testee.error().isEmpty());
+
+  // Directory traversal
+  Installer testee2({"allowed_dir"});
+  testee2.install(toFile("allowed_dir/../unallowed_dir/to3.txt"), data);
+  ASSERT_FALSE(testee2.error().isEmpty());
+
+  // Partial path match vulnerability (e.g. "allowed_dir_malicious")
+  Installer testee3({"allowed_dir"});
+  testee3.install(toFile("allowed_dir_malicious/to4.txt"), data);
+  ASSERT_FALSE(testee3.error().isEmpty());
+
+  // Case sensitivity test (if applicable)
+#if defined(Q_OS_WIN) || defined(Q_OS_MACOS)
+  Installer testee4({"allowed_dir"});
+  testee4.install(toFile("ALLOWED_DIR/to5.txt"), data);
+  ASSERT_TRUE(testee4.error().isEmpty());
+#else
+  Installer testee4({"allowed_dir"});
+  testee4.install(toFile("ALLOWED_DIR/to5.txt"), data);
+  ASSERT_FALSE(testee4.error().isEmpty());
+#endif
+}
 
 TEST(UpdateInstaller, FailRemove)
 {


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The application previously extracted files from an update payload and wrote them directly to the filesystem using paths provided in the payload's metadata. If an attacker provided a crafted update payload where the `path` contained directory traversal sequences (like `../`), the `Installer` would overwrite files outside the expected installation directory.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could gain Arbitrary File Overwrite capabilities, leading to remote code execution (e.g., by overwriting binaries like `screen-translator.exe` or dropping a malicious DLL in the app directory) or a denial of service.

🛡️ **Solution:** How the fix addresses the vulnerability
This fix introduces an explicit path-allowlist within the `Installer` class:
1. `Updater` passes its known directory mappings (expansions) to the `Installer`.
2. A new `isPathAllowed` method ensures that the target file path (after resolving `..` via `QDir::cleanPath`) is nested under one of the allowed directories.
3. The check prevents partial directory name matches (e.g., `allowed_dir_malicious`) by enforcing a trailing slash boundary.
4. The path comparison respects OS case-sensitivity rules (insensitive on Windows/macOS, sensitive on Linux).

---
*PR created automatically by Jules for task [4775191094645119657](https://jules.google.com/task/4775191094645119657) started by @Max97k*