### PR TITLE
🔒 Fix arbitrary file deletion vulnerability in updater

### DIFF
--- a/src/service/updates.cpp
+++ b/src/service/updates.cpp
@@ -620,8 +620,35 @@ void UpdateDelegate::paint(QPainter *painter,
 
 //
 
+Installer::Installer(const QList<QString> &allowedPaths)
+  : allowedPaths_(allowedPaths)
+{
+}
+
+bool Installer::isSafe(const QString &path) const
+{
+  if (allowedPaths_.isEmpty())
+    return false;
+
+  const auto targetPath = QDir::cleanPath(QFileInfo(path).absoluteFilePath());
+  for (const auto &allowedPath : allowedPaths_) {
+    const auto safePath = QDir::cleanPath(QFileInfo(allowedPath).absoluteFilePath());
+    if (targetPath == safePath || targetPath.startsWith(safePath + "/")) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 void Installer::checkInstall(const File &file)
 {
+  if (!isSafe(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Invalid path\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   QFileInfo installDir(QFileInfo(file.expandedPath).absolutePath());
   if (installDir.exists() && !installDir.isWritable()) {
     error_ +=
@@ -632,6 +659,12 @@ void Installer::checkInstall(const File &file)
 
 void Installer::remove(const File &file)
 {
+  if (!isSafe(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Invalid path\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   QFile f(file.expandedPath);
   if (!f.exists())
     return;
@@ -645,6 +678,12 @@ void Installer::remove(const File &file)
 
 void Installer::install(const File &file, const QByteArray &data)
 {
+  if (!isSafe(file.expandedPath)) {
+    error_ += QApplication::translate("Updates", "Invalid path\n%1")
+                  .arg(file.expandedPath);
+    return;
+  }
+
   auto installDir = QFileInfo(file.expandedPath).absoluteDir();
   if (!installDir.exists() && !installDir.mkpath(".")) {
     error_ += QApplication::translate("Updates", "Failed to create path\n%1")
@@ -774,6 +813,7 @@ void Updater::initView(QTreeView *view)
 
 void Updater::setExpansions(const QHash<QString, QString> &expansions)
 {
+  expansions_ = expansions;
   model_->setExpansions(expansions);
 }
 
@@ -788,7 +828,7 @@ void Updater::applyAction(Action action, const QVector<File> &files)
     LTRACE() << "applyAction" << int(action) << file.rawPath;
 
     if (action == Action::Remove) {
-      Installer installer;
+      Installer installer(expansions_.values());
       installer.remove(file);
       if (!installer.error().isEmpty()) {
         emit error(installer.error());
@@ -803,7 +843,7 @@ void Updater::applyAction(Action action, const QVector<File> &files)
       if (file.urls.isEmpty() || findDownload(file.urls.first()) != -1)
         continue;
 
-      Installer installer;
+      Installer installer(expansions_.values());
       installer.checkInstall(file);
 
       if (!installer.error().isEmpty()) {
@@ -851,7 +891,7 @@ void Updater::downloaded(const QUrl &url, const QByteArray &data)
     return;
   }
 
-  Installer installer;
+  Installer installer(expansions_.values());
   installer.install(file, unpacked);
   if (!installer.error().isEmpty()) {
     emit error(installer.error());

--- a/src/service/updates.h
+++ b/src/service/updates.h
@@ -105,13 +105,18 @@ private:
 class Installer
 {
 public:
+  explicit Installer(const QList<QString>& allowedPaths = {});
+
   void remove(const File& file);
   void install(const File& file, const QByteArray& data);
   void checkInstall(const File& file);
   const QString& error() const;
 
 private:
+  bool isSafe(const QString& path) const;
+
   QString error_;
+  QList<QString> allowedPaths_;
 };
 
 class AutoChecker : public QObject
@@ -168,6 +173,7 @@ private:
   std::unique_ptr<AutoChecker> autoChecker_;
   QVector<QUrl> updateUrls_;
   QVector<File> downloading_;
+  QHash<QString, QString> expansions_;
 };
 
 }  // namespace update

--- a/tests/updates_test.cpp
+++ b/tests/updates_test.cpp
@@ -3,6 +3,7 @@
 #include "updates.h"
 
 #include <QDebug>
+#include <QDir>
 #include <QFileInfo>
 #include <QSignalSpy>
 
@@ -50,7 +51,7 @@ TEST(UpdateInstaller, SuccessInstall)
 {
   ASSERT_TRUE(removeFile(t1));
 
-  Installer testee;
+  Installer testee({"test"});
   testee.install(toFile(t1), data);
   ASSERT_EQ(data, readFile(t1));
   ASSERT_TRUE(testee.error().isEmpty());
@@ -60,7 +61,7 @@ TEST(UpdateInstaller, SuccessRemove)
 {
   ASSERT_TRUE(writeFile(f1, data));
 
-  Installer testee;
+  Installer testee({QDir::currentPath()});
   testee.remove(toFile(f1));
   ASSERT_FALSE(QFile::exists(f1));
   ASSERT_TRUE(testee.error().isEmpty());
@@ -73,7 +74,7 @@ TEST(UpdateInstaller, FailInstallNoWritable)
   QFile f(t1);
   ASSERT_FALSE(f.isWritable());
 
-  Installer testee;
+  Installer testee({QDir::currentPath(), "/"});
   testee.install(toFile(t1), data);
   ASSERT_FALSE(testee.error().isEmpty());
 }
@@ -87,9 +88,25 @@ TEST(UpdateInstaller, FailRemove)
     return;
   ASSERT_FALSE(QFile::copy(f1, f1 + "1"));  // non writable
 
-  Installer testee;
+  Installer testee({QDir::currentPath(), "/var/log"});
   testee.remove(toFile(f1));
   ASSERT_FALSE(testee.error().isEmpty());
+}
+
+TEST(UpdateInstaller, PathValidation)
+{
+  Installer testee({"test"});
+
+  testee.remove(toFile("../malicious.txt"));
+  ASSERT_FALSE(testee.error().isEmpty());
+
+  Installer testee2({"test"});
+  testee2.install(toFile("../malicious.txt"), data);
+  ASSERT_FALSE(testee2.error().isEmpty());
+
+  Installer testee3({"test"});
+  testee3.install(toFile("test-malicious/test.txt"), data);
+  ASSERT_FALSE(testee3.error().isEmpty());
 }
 
 TEST(UpdateModel, ParseFail)


### PR DESCRIPTION
🎯 **What:** This PR fixes a vulnerability in `src/service/updates.cpp` where an unvalidated `expandedPath` was used to perform file system operations (`remove`, `install`, `checkInstall`).

⚠️ **Risk:** An attacker supplying a malicious update definition could leverage path traversal tricks (like `../`) or absolute paths to perform arbitrary file deletion, creation, or manipulation on the user's system under the permissions of the application.

🛡️ **Solution:** The fix introduces path validation via `Installer::isSafe(path)`. The `Installer` class now accepts a list of allowed directory paths via its constructor. `isSafe` uses `QFileInfo` and `QDir::cleanPath` to safely normalize and verify that any target file resides strictly within one of the designated safe installation directories, effectively blocking path traversal attempts.

---
*PR created automatically by Jules for task [17970297001462339496](https://jules.google.com/task/17970297001462339496) started by @Max97k*