### PR TITLE
🧹 Remove commented-out warnIfOutdated call and dead code

### DIFF
--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -60,8 +60,6 @@ Manager::Manager()
   if (settings_->showMessageOnStart)
     tray_->showInformation(QObject::tr("Screen translator started"));
 
-  // warnIfOutdated();
-
   QObject::connect(updater_.get(), &update::Updater::error,  //
                    tray_.get(), &TrayIcon::showError);
   QObject::connect(updater_.get(), &update::Updater::updatesAvailable,  //
@@ -80,22 +78,6 @@ Manager::~Manager()
     settings_->saveLastUpdateCheck();
     LTRACE() << "saved last update time";
   }
-}
-
-void Manager::warnIfOutdated()
-{
-  const auto now = QDateTime::currentDateTime();
-  const auto binaryInfo = QFileInfo(QApplication::applicationFilePath());
-  const auto date = binaryInfo.fileTime(QFile::FileTime::FileBirthTime);
-  const auto deadlineDays = 90;
-  if (date.daysTo(now) < deadlineDays)
-    return;
-  const auto updateDate = settings_->lastUpdateCheck;
-  if (updateDate.isValid() && updateDate.daysTo(now) < deadlineDays)
-    return;
-  tray_->showInformation(
-      QObject::tr("Current version might be outdated.\n"
-                  "Check for updates to silence this warning"));
 }
 
 void Manager::updateSettings()

--- a/src/manager.h
+++ b/src/manager.h
@@ -33,7 +33,6 @@ private:
   void setupUpdates(const Settings &settings);
   bool setupTrace(bool isOn);
   void finishTask(const TaskPtr &task);
-  void warnIfOutdated();
 
   std::unique_ptr<CommonModels> models_;
   std::unique_ptr<Settings> settings_;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
The patch removes a commented out call to `warnIfOutdated()` inside `src/manager.cpp:63`. Further investigation showed that this function is not being used anywhere else in the code. Therefore, the function's definition in `src/manager.cpp` and declaration in `src/manager.h` have been removed to eliminate dead code.

💡 **Why:** How this improves maintainability
Removing dead code and commented-out code snippets makes the source files cleaner and easier to read, preventing confusion for developers and eliminating unnecessary warnings from compilers or linters regarding unused private methods.

✅ **Verification:** How you confirmed the change is safe
Ran the full test suite via `python3 share/ci/test.py`. All 44 tests passed successfully, confirming that no existing logic was broken or negatively affected by this change.

✨ **Result:** The improvement achieved
A cleaner `src/manager.cpp` and `src/manager.h` file, completely devoid of the dead code and useless comment.

---
*PR created automatically by Jules for task [6825143785685899834](https://jules.google.com/task/6825143785685899834) started by @Max97k*