### PR TITLE
Fix Windows CI test failure restoring default size

### DIFF
--- a/src/service/widgetstate.cpp
+++ b/src/service/widgetstate.cpp
@@ -23,10 +23,10 @@ void handleGeometry(QSettings *settings, QWidget *widget, Action action)
 
   const auto name = widget->objectName() + QLatin1String("_geometry");
   if (action == Action::Save) {
-    settings->setValue(name, widget->geometry());
+    settings->setValue(name, widget->saveGeometry());
   } else {
     if (settings->contains(name))
-      widget->setGeometry(settings->value(name).toRect());
+      widget->restoreGeometry(settings->value(name).toByteArray());
   }
 }
 

--- a/tests/widgetstate_test.cpp
+++ b/tests/widgetstate_test.cpp
@@ -57,19 +57,8 @@ TEST_F(WidgetStateTest, BasicGeometrySaveRestore) {
     service::WidgetState::restore(&widget);
 
     // Verify geometry was restored
-    // On Windows, the geometry restoration might not match pixel-perfect for unshown widgets
-    // due to window frame adjustments, but we can verify it at least read some value.
-    // For offscreen platform it's exact. For others, it might adjust it.
-    // To fix Windows CI test failure where it restores to default size instead,
-    // we need to ensure the settings actually contain the value first.
-    QSettings checkSettings;
-    checkSettings.beginGroup("GUI");
-    if (checkSettings.contains("TestWidget_geometry")) {
-        // Only enforce exact match if settings engine successfully stored the Rect
-        // otherwise let it pass as platform differences with headless QSettings handling
-        // apply here.
-        EXPECT_EQ(widget.geometry(), QRect(10, 20, 100, 200));
-    }
+    // Using saveGeometry/restoreGeometry handles offscreen and different platforms properly
+    EXPECT_EQ(widget.geometry(), QRect(10, 20, 100, 200));
 }
 
 TEST_F(WidgetStateTest, SplitterStateSaveRestore) {


### PR DESCRIPTION
Fix Windows CI test failure where geometry restore used the default size instead of the actual size.

Changes:
* Replaced manual `setGeometry` and `geometry` logic with `saveGeometry()` and `restoreGeometry()` in `WidgetState`.
* Removed the Windows headless fallback block in `WidgetStateTest` as tests now exact match correctly across environments.

---
*PR created automatically by Jules for task [4572762821650234755](https://jules.google.com/task/4572762821650234755) started by @Max97k*