### PR TITLE
🧪 Add CommonModels testing improvement

### DIFF
--- a/src/commonmodels.cpp
+++ b/src/commonmodels.cpp
@@ -1,7 +1,7 @@
 #include "commonmodels.h"
 #include "settings.h"
-#include "ocr/winocr.h"
-#include "translate/translator.h"
+#include "winocr.h"
+#include "translator.h"
 
 CommonModels::CommonModels()
   : sourceLanguageModel_(std::make_unique<QStringListModel>())

--- a/src/commonmodels.cpp
+++ b/src/commonmodels.cpp
@@ -1,7 +1,7 @@
 #include "commonmodels.h"
 #include "settings.h"
-#include "winocr.h"
-#include "translator.h"
+#include "ocr/winocr.h"
+#include "translate/translator.h"
 
 CommonModels::CommonModels()
   : sourceLanguageModel_(std::make_unique<QStringListModel>())

--- a/tests/commonmodels_test.cpp
+++ b/tests/commonmodels_test.cpp
@@ -1,0 +1,53 @@
+#include <gtest/gtest.h>
+#include "../src/commonmodels.h"
+#include "../src/ocr/winocr.h"
+#include "../src/translate/translator.h"
+#include <QStringListModel>
+#include <QStringList>
+
+// Stubs for static methods used by CommonModels
+QStringList WinOcr::availableLanguageNames(const QString &path) {
+    return {"Zzz", "Aaa", "Mmm"};
+}
+
+QStringList Translator::availableTranslators(const QString &path) {
+    return {"Yyy", "Bbb", "Nnn"};
+}
+
+QStringList Translator::availableLanguageNames() {
+    return {"Xxx", "Ccc", "Ooo"};
+}
+
+TEST(CommonModelsTest, UpdatePopulatesAndSortsModels) {
+    CommonModels models;
+
+    EXPECT_EQ(models.sourceLanguageModel()->rowCount(), 0);
+    EXPECT_EQ(models.targetLanguageModel()->rowCount(), 0);
+    EXPECT_TRUE(models.translators().isEmpty());
+
+    models.update("tessdata", "translators");
+
+    // Verify source language model is populated and sorted
+    ASSERT_EQ(models.sourceLanguageModel()->rowCount(), 3);
+    EXPECT_EQ(models.sourceLanguageModel()->stringList().at(0), "Aaa");
+    EXPECT_EQ(models.sourceLanguageModel()->stringList().at(1), "Mmm");
+    EXPECT_EQ(models.sourceLanguageModel()->stringList().at(2), "Zzz");
+
+    // Verify translators are populated and sorted
+    ASSERT_EQ(models.translators().size(), 3);
+    EXPECT_EQ(models.translators().at(0), "Bbb");
+    EXPECT_EQ(models.translators().at(1), "Nnn");
+    EXPECT_EQ(models.translators().at(2), "Yyy");
+
+    // Verify target language model is populated and sorted
+    ASSERT_EQ(models.targetLanguageModel()->rowCount(), 3);
+    EXPECT_EQ(models.targetLanguageModel()->stringList().at(0), "Ccc");
+    EXPECT_EQ(models.targetLanguageModel()->stringList().at(1), "Ooo");
+    EXPECT_EQ(models.targetLanguageModel()->stringList().at(2), "Xxx");
+
+    // Verify targetLanguageModel is not repopulated if it already has rows
+    models.targetLanguageModel()->setStringList({"KeepMe"});
+    models.update("tessdata", "translators");
+    ASSERT_EQ(models.targetLanguageModel()->rowCount(), 1);
+    EXPECT_EQ(models.targetLanguageModel()->stringList().at(0), "KeepMe");
+}

--- a/tests/commonmodels_test.cpp
+++ b/tests/commonmodels_test.cpp
@@ -1,22 +1,7 @@
 #include <gtest/gtest.h>
 #include "../src/commonmodels.h"
-#include "../src/ocr/winocr.h"
-#include "../src/translate/translator.h"
 #include <QStringListModel>
 #include <QStringList>
-
-// Stubs for static methods used by CommonModels
-QStringList WinOcr::availableLanguageNames(const QString &path) {
-    return {"Zzz", "Aaa", "Mmm"};
-}
-
-QStringList Translator::availableTranslators(const QString &path) {
-    return {"Yyy", "Bbb", "Nnn"};
-}
-
-QStringList Translator::availableLanguageNames() {
-    return {"Xxx", "Ccc", "Ooo"};
-}
 
 TEST(CommonModelsTest, UpdatePopulatesAndSortsModels) {
     CommonModels models;

--- a/tests/mock_commonmodels_deps.cpp
+++ b/tests/mock_commonmodels_deps.cpp
@@ -1,0 +1,17 @@
+#include "../src/ocr/winocr.h"
+#include "../src/translate/translator.h"
+
+// Stubs for static methods used by CommonModels
+QStringList WinOcr::availableLanguageNames(const QString &path) {
+    Q_UNUSED(path);
+    return {"Zzz", "Aaa", "Mmm"};
+}
+
+QStringList Translator::availableTranslators(const QString &path) {
+    Q_UNUSED(path);
+    return {"Yyy", "Bbb", "Nnn"};
+}
+
+QStringList Translator::availableLanguageNames() {
+    return {"Xxx", "Ccc", "Ooo"};
+}

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,9 +1,11 @@
 CONFIG += c++17
 CONFIG -= app_bundle
 
+win32:DEFINES += _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
+
 QT += widgets network testlib
 
-INCLUDEPATH += $$PWD/../external $$PWD/../src/service $$PWD/../src $$PWD/../src/capture
+INCLUDEPATH += $$PWD/../external $$PWD/../src/service $$PWD/../src $$PWD/../src/capture $$PWD/../src/ocr $$PWD/../src/translate
 
 HEADERS += \
   ../src/languagecodes.h \
@@ -31,4 +33,5 @@ SOURCES += \
   mocknetworkaccessmanager.cpp \
   translation_pipeline_test.cpp \
   capturearea_test.cpp \
-  commonmodels_test.cpp
+  commonmodels_test.cpp \
+  mock_commonmodels_deps.cpp

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -10,10 +10,12 @@ HEADERS += \
   ../src/service/updates.h \
   ../src/service/widgetstate.h \
   ../src/task.h \
+  ../src/commonmodels.h \
   mocknetworkaccessmanager.h
 
 SOURCES += \
   ../external/gtest/gtest-all.cc \
+  ../src/commonmodels.cpp \
   ../src/languagecodes.cpp \
   ../src/service/geometryutils.cpp \
   ../src/service/updates.cpp \
@@ -28,4 +30,5 @@ SOURCES += \
   widgetstate_test.cpp \
   mocknetworkaccessmanager.cpp \
   translation_pipeline_test.cpp \
-  capturearea_test.cpp
+  capturearea_test.cpp \
+  commonmodels_test.cpp


### PR DESCRIPTION
🎯 **What:** The testing gap in `src/commonmodels.cpp` was addressed by adding a dedicated Google Test suite for `CommonModels`.
📊 **Coverage:** The tests now fully verify the initialization and update behavior of `CommonModels`, specifically ensuring the correct population and stable sorting of `sourceLanguageModel`, `targetLanguageModel`, and `translators`. They also check that the target language model is not needlessly repopulated if it already has rows.
✨ **Result:** Increased test coverage for model data management and ensured changes to these underlying data lists (which populate the UI) are verified for regression.

---
*PR created automatically by Jules for task [5685319565847284139](https://jules.google.com/task/5685319565847284139) started by @Max97k*