### PR TITLE
🔒 Fix SSL Certificate Verification Ignored Vulnerability

### DIFF
--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -43,7 +43,6 @@ const QString qs_useHunspell = "useHunspell";
 
 const QString qs_translationGroup = "Translation";
 const QString qs_doTranslation = "doTranslation";
-const QString qs_ignoreSslErrors = "ignoreSslErrors";
 const QString qs_translationLanguage = "translation_language";
 const QString qs_translationTimeout = "translation_timeout";
 const QString qs_translators = "translators";
@@ -183,7 +182,6 @@ Settings& Settings::operator=(const Settings& other)
   tessdataPath = other.tessdataPath;
   sourceLanguage = other.sourceLanguage;
   doTranslation = other.doTranslation;
-  ignoreSslErrors = other.ignoreSslErrors;
   targetLanguage = other.targetLanguage;
   translationTimeout = other.translationTimeout;
   translatorsPath = other.translatorsPath;
@@ -296,7 +294,6 @@ void Settings::saveTranslation(QSettings& settings) const
   settings.beginGroup(qs_translationGroup);
 
   settings.setValue(qs_doTranslation, doTranslation);
-  settings.setValue(qs_ignoreSslErrors, ignoreSslErrors);
   settings.setValue(qs_translationLanguage, targetLanguage);
   settings.setValue(qs_translationTimeout, int(translationTimeout.count()));
   settings.setValue(qs_translators, translators);
@@ -394,8 +391,6 @@ void Settings::loadTranslation(QSettings& settings)
   settings.beginGroup(qs_translationGroup);
 
   doTranslation = settings.value(qs_doTranslation, doTranslation).toBool();
-  ignoreSslErrors =
-      settings.value(qs_ignoreSslErrors, ignoreSslErrors).toBool();
   targetLanguage =
       settings.value(qs_translationLanguage, targetLanguage).toString();
   translationTimeout = std::chrono::seconds(

--- a/src/settings.h
+++ b/src/settings.h
@@ -69,7 +69,6 @@ public:
   QString sourceLanguage{"eng"};
 
   bool doTranslation{true};
-  bool ignoreSslErrors{false};
   LanguageId targetLanguage{"rus"};
   std::chrono::seconds translationTimeout{15};
   QString translatorsPath;

--- a/src/settingseditor.cpp
+++ b/src/settingseditor.cpp
@@ -266,7 +266,6 @@ Settings SettingsEditor::settings() const
   settings.userSubstitutions = ui->userSubstitutionsTable->substitutions();
 
   settings.doTranslation = ui->doTranslationCheck->isChecked();
-  settings.ignoreSslErrors = ui->ignoreSslCheck->isChecked();
   settings.translationTimeout =
       std::chrono::seconds(ui->translateTimeoutSpin->value());
   settings.targetLanguage =
@@ -327,7 +326,6 @@ void SettingsEditor::setSettings(const Settings &settings)
   ui->userSubstitutionsTable->setSubstitutions(settings.userSubstitutions);
 
   ui->doTranslationCheck->setChecked(settings.doTranslation);
-  ui->ignoreSslCheck->setChecked(settings.ignoreSslErrors);
   ui->translateTimeoutSpin->setValue(settings.translationTimeout.count());
   ui->translateLangCombo->setCurrentText(
       LanguageCodes::name(settings.targetLanguage));

--- a/src/settingseditor.ui
+++ b/src/settingseditor.ui
@@ -428,13 +428,6 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QCheckBox" name="ignoreSslCheck">
-           <property name="text">
-            <string>Ignore SSL errors</string>
-           </property>
-          </widget>
-         </item>
          <item row="4" column="1" colspan="2">
           <widget class="QComboBox" name="translateLangCombo" />
          </item>


### PR DESCRIPTION
🎯 **What:** Removed the "Ignore SSL errors" functionality and its checkbox from the Settings and Settings Editor UI.

⚠️ **Risk:** Providing users with an option to ignore SSL errors is dangerous as they might enable it without understanding the risks, exposing themselves to Man-in-the-Middle (MITM) attacks. This is especially risky when proxy passwords are also being handled by the application.

🛡️ **Solution:** Removed the checkbox from the UI (`src/settingseditor.ui`), removed the underlying tracking property from the `Settings` structure (`src/settings.h`, `src/settings.cpp`, `src/settingseditor.cpp`). As there were no instances in the repository where `ignoreSslErrors` was actively used to override SSL verification in native `QNetworkAccessManager` requests (possibly because it was part of the old QWebEngine pipeline that was dropped), removing this option prevents users from putting themselves into an insecure state while maintaining correct runtime operations. No actual network behaviour changed. Checked usage thoroughly and made sure all instances were completely gone. Tested that everything compiles correctly and tests run properly.

---
*PR created automatically by Jules for task [4684278325724700686](https://jules.google.com/task/4684278325724700686) started by @Max97k*