### PR TITLE
🧪 Add error path tests for WinOcr recognition

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -31,6 +31,7 @@ SOURCES += \
   capturearea_test.cpp
 
 win32 {
+  DEFINES += _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
   HEADERS += ../src/ocr/winocr.h
   SOURCES += \
     ../src/ocr/winocr.cpp \

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -32,6 +32,7 @@ SOURCES += \
 
 win32 {
   DEFINES += _SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS
+  LIBS += -lwindowsapp
   HEADERS += ../src/ocr/winocr.h
   SOURCES += \
     ../src/ocr/winocr.cpp \

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -29,3 +29,10 @@ SOURCES += \
   mocknetworkaccessmanager.cpp \
   translation_pipeline_test.cpp \
   capturearea_test.cpp
+
+win32 {
+  HEADERS += ../src/ocr/winocr.h
+  SOURCES += \
+    ../src/ocr/winocr.cpp \
+    winocr_test.cpp
+}

--- a/tests/winocr_test.cpp
+++ b/tests/winocr_test.cpp
@@ -1,0 +1,46 @@
+#include <gtest/gtest.h>
+#include <QPixmap>
+#include <QImage>
+#include <QStringList>
+#include <QObject>
+#include "../src/ocr/winocr.h"
+#include "../src/languagecodes.h"
+
+// The test file is only compiled on Windows via tests.pro
+#if defined(Q_OS_WIN)
+TEST(WinOcrTest, HandlesHResultErrorLargeImage) {
+    WinOcr ocr(LanguageId("eng"), "");
+    if (!ocr.isValid()) {
+        GTEST_SKIP() << "OCR not available";
+    }
+
+    // Feed an image that exceeds MaxImageDimension (which is typically 2600 to 4000)
+    // to cause an ArgumentException / hresult_error in WinRT OcrEngine
+    // A 5000x5000 image consumes ~100MB, safely triggering the exception without causing OOM.
+    QImage image(5000, 5000, QImage::Format_RGBA8888);
+    image.fill(Qt::white);
+    QPixmap pixmap = QPixmap::fromImage(image);
+
+    QString result = ocr.recognize(pixmap);
+
+    EXPECT_TRUE(result.isEmpty());
+    EXPECT_FALSE(ocr.error().isEmpty());
+    EXPECT_NE(ocr.error(), QObject::tr("Unknown error during WinOcr recognize"));
+    EXPECT_NE(ocr.error(), QObject::tr("Failed to recognize text or no text selected"));
+}
+
+TEST(WinOcrTest, SuccessfulRecognition) {
+    WinOcr ocr(LanguageId("eng"), "");
+    if (!ocr.isValid()) {
+        GTEST_SKIP() << "OCR not available";
+    }
+
+    QImage image(10, 10, QImage::Format_RGBA8888);
+    image.fill(Qt::white);
+    QPixmap pixmap = QPixmap::fromImage(image);
+
+    QString result = ocr.recognize(pixmap);
+    // Result might be empty if the image is just white, but there shouldn't be an error
+    EXPECT_TRUE(ocr.error().isEmpty() || ocr.error() == QObject::tr("Failed to recognize text or no text selected"));
+}
+#endif


### PR DESCRIPTION
This PR introduces unit tests to cover the previously untested error paths (catch blocks) in the Windows OCR recognition routine. The tests operate by triggering the OCR engine's dimension limits using an intentionally oversized QImage, which successfully simulates the error flow on a Windows machine without the need for brittle dependency injection or mocking of system SDKs. Tests are fully compliant with cross-platform builds and guarded correctly in both source and `qmake` settings.

---
*PR created automatically by Jules for task [12122077332920312272](https://jules.google.com/task/12122077332920312272) started by @Max97k*